### PR TITLE
Use process.resourcesPath so that macOS can find the resource directory

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -7,8 +7,8 @@ const Store = require('electron-store')
 const store = new Store()
 
 let proxy // Defined later when an option is chosen
-const resourcesPath = fs.existsSync('resources/app')
-    ? 'resources/app/' // Packaged with electron-forge
+const resourcesPath = fs.existsSync(process.resourcesPath.concat('/app/'))
+    ? process.resourcesPath.concat('/app/') // Packaged with electron-forge
     : './' // npm start
 
 


### PR DESCRIPTION
Currently, resourcesPath in index.js looks directly for 'resources/app' to decide whether or not to use the relative directory, or resources/app/. However, for macOS, 'resources/app'  will not exist in the packaged app, as the structure is instead '/Contents/Resources/app'. As a result, macOS then uses the path './', which then causes the resources folder to not be found. 

Using the electron builtin `process.resourcesPath` ensures we check for the correct resources path regardless of OS.

I have tested and confirmed this builds and runs on macOS, though someone should probably confirm and verify this doesn't break anything on other platforms.