### PR TITLE
Scripting save load

### DIFF
--- a/html/mainPage/index.html
+++ b/html/mainPage/index.html
@@ -101,15 +101,16 @@
         <h3>Scripting (beta)</h3>
         Scripting allows you to modify and inject packets on-the-fly
         <br><br>
-        <input id="enableScripting" name="enableScripting" onchange="sharedVars.scripting.updateScript(true)"
-               type="checkbox">
+        <label class="switch">
+            <input id="enableScripting" onchange="sharedVars.scripting.updateScript(true)" type="checkbox">
+            <span class="slider round"></span>
+        </label>
         <label for="enableScripting">Enable scripting</label>
-        &nbsp;
-        <button onclick="saveScript()">Save</button>
-        <button onclick="loadScript()">Load</button>
+        <button id="btnScriptLoad" onclick="loadScript()" style="margin-left: 16px;">Load</button>
+        <button id="btnScriptSave" onclick="saveScript(false)" style="margin-left: 8px;" disabled>Save</button>
+        <button id="btnScriptSaveAs" onclick="saveScript(true)" style="margin-left: 8px;">Save as..</button>
         <br><br>
-        <textarea id="scriptEditor">
-      </textarea>
+        <textarea id="scriptEditor"></textarea>
         <br>
         <a href="#" onclick="resetScriptEditor()">Reset</a>
     </div>

--- a/html/mainPage/js/ipcHandler.js
+++ b/html/mainPage/js/ipcHandler.js
@@ -74,4 +74,14 @@ exports.setup = function (passedSharedVars) {
     }))
   })
 
+  sharedVars.ipcRenderer.on('enableBtnScriptSave', (event, arg) => {
+    document.getElementById('btnScriptSave').disabled = false
+    document.getElementById('btnScriptSave').title = arg
+  })
+
+sharedVars.ipcRenderer.on('disableBtnScriptSave', (event, arg) => {
+  document.getElementById('btnScriptSave').disabled = true
+  document.getElementById('btnScriptSave').title = ''
+})
+
 }

--- a/html/mainPage/js/main.js
+++ b/html/mainPage/js/main.js
@@ -672,8 +672,12 @@ function loadLog() {
   sharedVars.ipcRenderer.send('loadLog', '')
 }
 
-function saveScript() {
-  sharedVars.ipcRenderer.send('saveScript', window.scriptEditor.getDoc().getValue() )
+function saveScript( newfile = true ) {
+  if (newfile) {
+    sharedVars.ipcRenderer.send('saveAsScript', window.scriptEditor.getDoc().getValue())
+  } else  {
+    sharedVars.ipcRenderer.send('saveScript', window.scriptEditor.getDoc().getValue())
+  }
 }
 
 function loadScript() {

--- a/html/mainPage/js/scripting.js
+++ b/html/mainPage/js/scripting.js
@@ -33,6 +33,8 @@ exports.downstreamHandler = function (meta, data, server, client) {
   window.resetScriptEditor = function () {
     // document.getElementById('scriptEditor').value = defaultScript
     window.scriptEditor.getDoc().setValue(defaultScript)
+    document.getElementById('btnScriptSave').disabled = true
+    document.getElementById('btnScriptSave').title = ''
   }
   window.scriptEditor = CodeMirror.fromTextArea(document.getElementById('scriptEditor'), { // window. stops standardjs from complaining
     lineNumbers: true,

--- a/html/mainPage/js/scripting.js
+++ b/html/mainPage/js/scripting.js
@@ -33,6 +33,8 @@ exports.downstreamHandler = function (meta, data, server, client) {
   window.resetScriptEditor = function () {
     // document.getElementById('scriptEditor').value = defaultScript
     window.scriptEditor.getDoc().setValue(defaultScript)
+    // reset save button
+    // todo: maybe confirm dialog, if there are unsaved changes?
     document.getElementById('btnScriptSave').disabled = true
     document.getElementById('btnScriptSave').title = ''
   }

--- a/html/shared.css
+++ b/html/shared.css
@@ -15,8 +15,16 @@ input, select, button {
   padding: 10px;
   outline: none;
 }
+button, input[type=submit] {
+   cursor: pointer;
+}
 button:hover, input[type=submit]:hover {
   background: #1F1F1F;
+}
+button:disabled, input[type=submit]:disabled {
+  background: #191919;
+  color: rgba(255,255,255,0.5);
+  cursor: not-allowed;
 }
 a {
   color: rgba(255, 255, 255, 0.8);
@@ -32,6 +40,8 @@ a:active {
   display: inline-block;
   width: 42px;
   height: 24px;
+  vertical-align: middle;
+  margin-right: 3px;
 }
 
 .switch input {


### PR DESCRIPTION
Change load/save behaive to remember the current file loaded, to save/overwrite it without asking for the path again.
- Add style for disabled buttons. 
- Add pointer-cursor for buttons.
- Add margin-right for switch (styled checkbox).
- Changed checkbox with switch for scriptenable.
- In scriptStateChange(), prevent the user-script to be executed by _eval(), if scripting is disabled.
- Clean-up code in packetHandler().

![image](https://user-images.githubusercontent.com/42624289/173830358-7b6a0478-5bce-4433-907b-8f2c5cf47b83.png)
