### PR TITLE
Strictly enforce the node version required

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+engine-strict=true


### PR DESCRIPTION
This is helpful to avoid node versions that will fail. With loud npm install output, warnings can go unseen. With this change because of the engine requirements specified upstream by the minecraft-protocol package if someone attempts to npm install with an unsupported version of node the process will abort with an error.

<img width="968" alt="Screenshot 2023-08-19 at 5 41 29 PM" src="https://github.com/Heath123/pakkit/assets/1624718/53fb7e6b-bc63-4a1f-8da2-9c3164cd75dd">
